### PR TITLE
+ed interactive graph traversal and node shelf

### DIFF
--- a/src/components/NodeShelf.jsx
+++ b/src/components/NodeShelf.jsx
@@ -1,0 +1,194 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { ChevronUp } from 'lucide-react';
+
+const NodeShelf = ({ activePage, pages, onNodeSelect, isMobile }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dragY, setDragY] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const shelfRef = useRef(null);
+  const dragStartY = useRef(0);
+  const dragStartOpen = useRef(false);
+
+  const COLLAPSED_HEIGHT = 56;
+  const OPEN_HEIGHT = isMobile ? 320 : 360;
+
+  // Swipe / drag handle
+  const handlePointerDown = (e) => {
+    setIsDragging(true);
+    dragStartY.current = e.clientY || e.touches?.[0]?.clientY || 0;
+    dragStartOpen.current = isOpen;
+    setDragY(0);
+  };
+
+  const handlePointerMove = (e) => {
+    if (!isDragging) return;
+    const clientY = e.clientY || e.touches?.[0]?.clientY || 0;
+    const dy = clientY - dragStartY.current;
+    setDragY(dy);
+  };
+
+  const handlePointerUp = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+
+    const threshold = 40;
+    if (dragStartOpen.current) {
+      // Was open: drag down to close
+      if (dragY > threshold) {
+        setIsOpen(false);
+      }
+    } else {
+      // Was collapsed: drag up to open
+      if (dragY < -threshold) {
+        setIsOpen(true);
+      }
+    }
+    setDragY(0);
+  };
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const onMove = (e) => handlePointerMove(e);
+    const onUp = () => handlePointerUp();
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    window.addEventListener('touchmove', onMove);
+    window.addEventListener('touchend', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('touchmove', onMove);
+      window.removeEventListener('touchend', onUp);
+    };
+  });
+
+  // Compute visual translation for drag feedback
+  const computeTranslateY = () => {
+    if (!isDragging) return 0;
+    if (isOpen) {
+      // Dragging down from open state — allow positive drag only (to close)
+      return Math.max(0, Math.min(dragY, OPEN_HEIGHT - COLLAPSED_HEIGHT));
+    } else {
+      // Dragging up from collapsed — allow negative drag only (to open)
+      return Math.min(0, Math.max(dragY, -(OPEN_HEIGHT - COLLAPSED_HEIGHT)));
+    }
+  };
+
+  const translateY = computeTranslateY();
+  const currentHeight = isOpen
+    ? OPEN_HEIGHT - translateY
+    : COLLAPSED_HEIGHT - translateY;
+
+  const seeAlsoLinks = activePage?.seeAlso || [];
+  const parentPage = activePage ? pages.find(p => p.children?.includes(activePage.id)) : null;
+  const childPages = activePage ? pages.filter(p => activePage.children?.includes(p.id)) : [];
+
+  return (
+    <div
+      ref={shelfRef}
+      className="fixed bottom-0 left-0 right-0 z-50"
+      style={{
+        height: `${currentHeight}px`,
+        transition: isDragging ? 'none' : 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        pointerEvents: 'auto',
+      }}
+    >
+      <div className="h-full bg-slate-900/95 backdrop-blur-md rounded-t-2xl border-t border-slate-700 shadow-2xl flex flex-col overflow-hidden">
+        {/* Drag handle area */}
+        <div
+          className="flex-shrink-0 cursor-grab active:cursor-grabbing select-none"
+          onMouseDown={handlePointerDown}
+          onTouchStart={(e) => handlePointerDown(e.touches[0])}
+          onClick={() => { if (!isDragging || Math.abs(dragY) < 5) setIsOpen(prev => !prev); }}
+        >
+          {/* Handle bar */}
+          <div className="flex justify-center pt-2 pb-1">
+            <div className="w-10 h-1 rounded-full bg-slate-600" />
+          </div>
+
+          {/* Title row */}
+          <div className="flex items-center justify-between px-4 pb-2">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              {activePage?.thumbnail && (
+                <img
+                  src={activePage.thumbnail}
+                  alt=""
+                  className="w-7 h-7 rounded-full object-cover flex-shrink-0 border border-slate-600"
+                />
+              )}
+              <span className="text-white font-medium text-sm truncate">
+                {activePage?.title || 'No page selected'}
+              </span>
+            </div>
+            <ChevronUp
+              size={18}
+              className={`text-slate-400 flex-shrink-0 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
+            />
+          </div>
+        </div>
+
+        {/* Expanded content */}
+        <div className="flex-1 overflow-y-auto px-4 pb-4" style={{ opacity: isOpen ? 1 : 0, transition: 'opacity 0.2s' }}>
+          {/* Connected pages */}
+          {(parentPage || childPages.length > 0) && (
+            <div className="mb-3">
+              <div className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold mb-1.5">Graph connections</div>
+              <div className="flex flex-wrap gap-1.5">
+                {parentPage && (
+                  <button
+                    onClick={() => onNodeSelect(parentPage)}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors"
+                  >
+                    {parentPage.thumbnail && (
+                      <img src={parentPage.thumbnail} alt="" className="w-4 h-4 rounded-full object-cover" />
+                    )}
+                    <span className="text-xs text-blue-300 truncate max-w-[120px]">{parentPage.title}</span>
+                    <span className="text-[9px] text-slate-500">parent</span>
+                  </button>
+                )}
+                {childPages.map(child => (
+                  <button
+                    key={child.id}
+                    onClick={() => onNodeSelect(child)}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 border border-slate-700 transition-colors"
+                  >
+                    {child.thumbnail && (
+                      <img src={child.thumbnail} alt="" className="w-4 h-4 rounded-full object-cover" />
+                    )}
+                    <span className="text-xs text-slate-300 truncate max-w-[120px]">{child.title}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* See Also links */}
+          {seeAlsoLinks.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold mb-1.5">Related pages</div>
+              <div className="flex flex-wrap gap-1.5">
+                {seeAlsoLinks.map((link, i) => (
+                  <button
+                    key={i}
+                    onClick={() => onNodeSelect({ title: link.title, url: link.url })}
+                    className="px-2.5 py-1.5 rounded-lg bg-slate-800/60 hover:bg-blue-900/40 border border-slate-700/50 hover:border-blue-600/50 transition-colors"
+                  >
+                    <span className="text-xs text-slate-300">{link.title}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {!parentPage && childPages.length === 0 && seeAlsoLinks.length === 0 && (
+            <div className="text-xs text-slate-500 text-center py-4">
+              No related pages available
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NodeShelf;

--- a/src/components/WikiNavTree.jsx
+++ b/src/components/WikiNavTree.jsx
@@ -7,8 +7,10 @@ import PWAInstallPrompt from './PWAInstallPrompt';
 import MobileBottomNav from './MobileBottomNav';
 import PullToRefresh from './PullToRefresh';
 import RabbitHoleShelf from './RabbitHoleShelf';
+import NodeShelf from './NodeShelf';
 import { usePullToRefresh } from '../hooks/usePullToRefresh';
 import { useSmartPanning } from '../hooks/useSmartPanning';
+import useGraphTraversal from '../hooks/useGraphTraversal';
 import MobileScrollHints from './MobileScrollHints';
 import { useWikipediaSearch } from '../hooks/useWikipediaSearch';
 import {
@@ -826,6 +828,23 @@ const WikiNavTree = () => {
 
   // Smart panning with boundaries
   const { pan, setPan, panLimits } = useSmartPanning(pages, zoom, svgRef, isMobile);
+
+  // Graph traversal: press-hold-drag to navigate related pages
+  const {
+    traversalState,
+    handleTraversalPointerDown,
+    handleTraversalPointerMove,
+    handleTraversalPointerUp,
+    cancelTraversal,
+  } = useGraphTraversal({
+    pages,
+    activePage,
+    zoom,
+    pan,
+    svgRef,
+    onNavigate: (pageInfo) => loadNewPage(pageInfo),
+    isMobile,
+  });
 
   // Pull to refresh functionality for mobile
   const { isRefreshing: isPullRefreshing, pullDistance, bindRefresh } = usePullToRefresh(
@@ -2217,17 +2236,35 @@ const WikiNavTree = () => {
             <div className="h-full flex flex-col">
               {/* Graph SVG container */}
               <div className="flex-1 overflow-hidden">
-                <svg 
-                  ref={svgRef} 
-                  width="100%" 
-                  height="100%" 
-                  onWheel={handleWheel} 
-                  onMouseDown={handleMouseDown}
-                  onTouchStart={handleTouchStart}
-                  onTouchMove={handleTouchMove}
-                  onTouchEnd={() => lastPinchDistance.current = null}
-                  style={{ 
-                    cursor: isDragging ? 'grabbing' : 'grab',
+                <svg
+                  ref={svgRef}
+                  width="100%"
+                  height="100%"
+                  onWheel={handleWheel}
+                  onMouseDown={(e) => {
+                    handleTraversalPointerDown(e);
+                    if (!traversalState) handleMouseDown(e);
+                  }}
+                  onMouseMove={(e) => {
+                    handleTraversalPointerMove(e);
+                  }}
+                  onMouseUp={(e) => {
+                    handleTraversalPointerUp(e);
+                  }}
+                  onTouchStart={(e) => {
+                    handleTraversalPointerDown(e);
+                    if (!traversalState) handleTouchStart(e);
+                  }}
+                  onTouchMove={(e) => {
+                    handleTraversalPointerMove(e);
+                    if (!traversalState) handleTouchMove(e);
+                  }}
+                  onTouchEnd={() => {
+                    handleTraversalPointerUp();
+                    lastPinchDistance.current = null;
+                  }}
+                  style={{
+                    cursor: traversalState ? 'none' : isDragging ? 'grabbing' : 'grab',
                     fontSize: isMobile ? '0.6rem' : 'inherit',
                     touchAction: isMobile ? 'pan-x pan-y' : 'none'
                   }}
@@ -2262,6 +2299,91 @@ const WikiNavTree = () => {
                       )
                     ))}
                     {renderSeeAlsoNodes()}
+
+                    {/* Traversal overlay: radial related nodes on press-hold */}
+                    {traversalState && (
+                      <>
+                        {/* Dim background pulse on source node */}
+                        <circle
+                          cx={traversalState.sourceNode.x}
+                          cy={traversalState.sourceNode.y}
+                          r={isMobile ? 30 : 50}
+                          fill="rgba(59, 130, 246, 0.15)"
+                          stroke="rgba(59, 130, 246, 0.4)"
+                          strokeWidth="2"
+                          className="animate-pulse"
+                        />
+
+                        {/* Edges from source to related nodes */}
+                        {traversalState.relatedNodes.map(rn => (
+                          <line
+                            key={`trav-edge-${rn.id}`}
+                            x1={traversalState.sourceNode.x}
+                            y1={traversalState.sourceNode.y}
+                            x2={rn.x}
+                            y2={rn.y}
+                            stroke={traversalState.hoveredNode?.id === rn.id ? '#3b82f6' : '#475569'}
+                            strokeWidth={traversalState.hoveredNode?.id === rn.id ? 2.5 : 1}
+                            strokeDasharray={traversalState.hoveredNode?.id === rn.id ? 'none' : '4 3'}
+                            opacity={traversalState.hoveredNode?.id === rn.id ? 1 : 0.5}
+                            style={{ transition: 'all 0.15s ease-out' }}
+                          />
+                        ))}
+
+                        {/* Related nodes */}
+                        {traversalState.relatedNodes.map(rn => {
+                          const isHovered = traversalState.hoveredNode?.id === rn.id;
+                          const nodeScale = isMobile ? 0.45 : 0.75;
+                          const r = (isHovered ? 38 : 30) * nodeScale;
+
+                          // Break title into lines
+                          const words = rn.title.split(' ');
+                          const lines = words.reduce((acc, word) => {
+                            const last = acc[acc.length - 1];
+                            if (!last || (last + ' ' + word).length > 12) acc.push(word);
+                            else acc[acc.length - 1] = `${last} ${word}`;
+                            return acc;
+                          }, []);
+
+                          return (
+                            <g key={`trav-node-${rn.id}`} transform={`translate(${rn.x},${rn.y})`}>
+                              {/* Glow on hover */}
+                              {isHovered && (
+                                <circle
+                                  r={r + 6}
+                                  fill="none"
+                                  stroke="#3b82f6"
+                                  strokeWidth="2"
+                                  opacity="0.6"
+                                  className="animate-pulse"
+                                />
+                              )}
+                              <circle
+                                r={r}
+                                fill={isHovered ? '#1e40af' : '#1e293b'}
+                                stroke={isHovered ? '#60a5fa' : '#475569'}
+                                strokeWidth={isHovered ? 2 : 1}
+                                style={{ transition: 'all 0.15s ease-out' }}
+                              />
+                              <text
+                                textAnchor="middle"
+                                dy={r + 14 * nodeScale}
+                                fill={isHovered ? '#93c5fd' : '#94a3b8'}
+                                fontSize={isMobile ? 7 : 11}
+                                fontWeight={isHovered ? 'bold' : 'normal'}
+                                style={{ transition: 'all 0.15s ease-out', pointerEvents: 'none' }}
+                              >
+                                {lines.map((line, i) => (
+                                  <tspan key={i} x="0" dy={i === 0 ? 0 : '1.2em'}>
+                                    {line}
+                                  </tspan>
+                                ))}
+                              </text>
+                            </g>
+                          );
+                        })}
+                      </>
+                    )}
                   </g>
 
                 </svg>
@@ -2348,6 +2470,24 @@ const WikiNavTree = () => {
         </div>
       </div>
   
+      {/* Node Shelf - collapsed at bottom, shows selected node */}
+      {pages.length > 0 && (
+        <NodeShelf
+          activePage={activePage}
+          pages={pages}
+          onNodeSelect={(pageInfo) => {
+            // If it's an existing page in the tree, just click it
+            const existing = pages.find(p => p.title === pageInfo.title);
+            if (existing) {
+              handleNodeClick(existing);
+            } else {
+              loadNewPage({ title: pageInfo.title, url: pageInfo.url || `https://en.wikipedia.org/wiki/${pageInfo.title.replace(/\s+/g, '_')}` });
+            }
+          }}
+          isMobile={isMobile}
+        />
+      )}
+
       {/* Footer */}
       <div className="w-full bg-white border-t py-1 px-4 flex justify-center items-center">
         <a 

--- a/src/hooks/useGraphTraversal.js
+++ b/src/hooks/useGraphTraversal.js
@@ -1,0 +1,157 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+/**
+ * useGraphTraversal - Press-hold-drag gesture for graph node traversal
+ *
+ * Press and hold a node to reveal its related (See Also) pages in a radial layout.
+ * Drag finger/cursor to a related page to highlight it.
+ * Lift to navigate to the highlighted page.
+ */
+const useGraphTraversal = ({ pages, activePage, zoom, pan, svgRef, onNavigate, isMobile }) => {
+  const [traversalState, setTraversalState] = useState(null);
+
+  const holdTimerRef = useRef(null);
+  const isHoldingRef = useRef(false);
+  const movedRef = useRef(false);
+  const startPosRef = useRef({ x: 0, y: 0 });
+  const onNavigateRef = useRef(onNavigate);
+  const traversalStateRef = useRef(traversalState);
+
+  // Keep refs in sync
+  useEffect(() => { onNavigateRef.current = onNavigate; }, [onNavigate]);
+  useEffect(() => { traversalStateRef.current = traversalState; }, [traversalState]);
+
+  const HOLD_DELAY = 400;
+  const MOVE_THRESHOLD = 8;
+  const RELATED_RADIUS = isMobile ? 100 : 140;
+
+  const screenToGraph = useCallback((clientX, clientY) => {
+    if (!svgRef.current) return { x: 0, y: 0 };
+    const rect = svgRef.current.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left - pan.x) / zoom,
+      y: (clientY - rect.top - pan.y) / zoom,
+    };
+  }, [zoom, pan, svgRef]);
+
+  const findNodeAt = useCallback((gx, gy, nodeList) => {
+    const hitRadius = isMobile ? 25 : 45;
+    for (const node of nodeList) {
+      const dx = node.x - gx;
+      const dy = node.y - gy;
+      if (dx * dx + dy * dy < hitRadius * hitRadius) {
+        return node;
+      }
+    }
+    return null;
+  }, [isMobile]);
+
+  const buildRelatedNodes = useCallback((sourceNode) => {
+    const links = sourceNode.seeAlso || [];
+    if (links.length === 0) return [];
+
+    const N = links.length;
+    const cx = sourceNode.x;
+    const cy = sourceNode.y;
+
+    return links.map((link, i) => {
+      const angle = (-Math.PI / 2) + (i / Math.max(N - 1, 1)) * Math.PI;
+      return {
+        id: `traversal-${i}-${link.title}`,
+        title: link.title,
+        url: link.url?.startsWith('http') ? link.url : `https://en.wikipedia.org${link.url}`,
+        x: cx + RELATED_RADIUS * Math.cos(angle),
+        y: cy + RELATED_RADIUS * Math.sin(angle),
+      };
+    });
+  }, [RELATED_RADIUS]);
+
+  const cancelHold = useCallback(() => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    isHoldingRef.current = false;
+  }, []);
+
+  const endTraversal = useCallback(() => {
+    const state = traversalStateRef.current;
+    cancelHold();
+    if (state?.hoveredNode) {
+      onNavigateRef.current({ title: state.hoveredNode.title, url: state.hoveredNode.url });
+    }
+    setTraversalState(null);
+  }, [cancelHold]);
+
+  const handleTraversalPointerDown = useCallback((e) => {
+    if (e.touches && e.touches.length > 1) return;
+    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    const clientY = e.touches ? e.touches[0].clientY : e.clientY;
+
+    startPosRef.current = { x: clientX, y: clientY };
+    movedRef.current = false;
+
+    const gp = screenToGraph(clientX, clientY);
+    const hitNode = findNodeAt(gp.x, gp.y, pages);
+    if (!hitNode) return;
+
+    isHoldingRef.current = true;
+
+    holdTimerRef.current = setTimeout(() => {
+      if (!isHoldingRef.current || movedRef.current) return;
+      const related = buildRelatedNodes(hitNode);
+      if (related.length === 0) return;
+
+      setTraversalState({
+        sourceNode: hitNode,
+        relatedNodes: related,
+        hoveredNode: null,
+        origin: { x: clientX, y: clientY },
+      });
+    }, HOLD_DELAY);
+  }, [pages, screenToGraph, findNodeAt, buildRelatedNodes]);
+
+  const handleTraversalPointerMove = useCallback((e) => {
+    const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    const clientY = e.touches ? e.touches[0].clientY : e.clientY;
+
+    const dx = clientX - startPosRef.current.x;
+    const dy = clientY - startPosRef.current.y;
+    if (dx * dx + dy * dy > MOVE_THRESHOLD * MOVE_THRESHOLD) {
+      movedRef.current = true;
+      if (!traversalStateRef.current) {
+        cancelHold();
+      }
+    }
+
+    if (!traversalStateRef.current) return;
+
+    const gp = screenToGraph(clientX, clientY);
+    const hitRelated = findNodeAt(gp.x, gp.y, traversalStateRef.current.relatedNodes);
+    setTraversalState(prev => prev ? { ...prev, hoveredNode: hitRelated } : null);
+  }, [screenToGraph, findNodeAt, cancelHold]);
+
+  const handleTraversalPointerUp = useCallback(() => {
+    if (traversalStateRef.current) {
+      endTraversal();
+    } else {
+      cancelHold();
+    }
+  }, [endTraversal, cancelHold]);
+
+  useEffect(() => {
+    return () => {
+      if (holdTimerRef.current) clearTimeout(holdTimerRef.current);
+    };
+  }, []);
+
+  return {
+    traversalState,
+    handleTraversalPointerDown,
+    handleTraversalPointerMove,
+    handleTraversalPointerUp,
+    cancelTraversal: () => { cancelHold(); setTraversalState(null); },
+  };
+};
+
+export default useGraphTraversal;


### PR DESCRIPTION
- Press-hold on graph node reveals related pages in radial layout
- Drag to a related page to highlight, lift finger to navigate
- Bottom shelf shows selected node title, swipe up/down to open/close
- Shelf displays graph connections and See Also links when expanded